### PR TITLE
reduce compiled library size

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   },
   "homepage": "https://github.com/AgentME/ud#readme",
   "dependencies": {
+    "array-range": "^1.0.1",
     "babel-runtime": "^5.8.20",
-    "lodash": "^3.10.1"
+    "indexof": "0.0.1",
+    "zip-object": "^0.1.0"
   },
   "devDependencies": {
     "babel": "^5.8.21",


### PR DESCRIPTION
This patch swaps `lodash` out for more granular libs and cuts the compiled size from 460k to 50k:

```
$ browserify -r . | wc -c # before
460867
$ browserify -r . | wc -c # after
50442
```

https://github.com/substack/react-starter-hmr/issues/3

This may change browser support since browsers will need to have `.filter()` and `.forEach()`, but those can be shimmed. If you'd like I can add more focused libs for `filter`, `forEach`, `map`, etc. The size will be slightly larger, but much smaller than with all of lodash.