### PR TITLE
building for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ brand new counter. If `ud.defn` were not used to define the inc function, then
 the previously exported function that other modules may have local copies of
 would not be updated.
 
+### Building for Production
+
+If you want to avoid the extra bytes that make `ud` work in your production
+build which does not need hot module replacement, you can swap `require('ud')`
+for `require('ud/production')`.
+
+In browserify, you can do this with:
+
+```
+browserify -r ud/production:ud main.js > bundle.js
+```
+
+or from the API:
+
+``` js
+var b = browserify('main.js')
+  .require('ud/production', { target: 'ud' })
+```
+
 ## Types
 
 Full [Flow Type](http://flowtype.org/) declarations for this module are

--- a/production.js
+++ b/production.js
@@ -1,0 +1,3 @@
+exports.defonce = function (module, f) { return f };
+exports.defobj = function (module, obj) { return obj };
+exports.defn = function (module, f) { return f };


### PR DESCRIPTION
This patch is an alternative approach from [pulls/#1](https://github.com/AgentME/ud/pull/1) (but not necessarily exclusive) to solve [react-starter-hmr/issues/3](https://github.com/substack/react-starter-hmr/issues/3).

It adds a `production.js` to the package root so that end-users can `require('ud/production')` in their production builds. I've added notes for how to do this with browserify, but as a separate commit in case you want to cherry-pick around it. For example, with this patch, end-users can do:

```
browserify -r ud/production:ud main.js > bundle.js
```

in their production, non-dev builds where the heft of hot module hooks are unwanted.